### PR TITLE
partial fix for issue retrieving google user name

### DIFF
--- a/src/libs/GoogleHelper.js
+++ b/src/libs/GoogleHelper.js
@@ -106,7 +106,8 @@ export default class GoogleHelper {
    */
   getUsername() {
     if (this.currentUser_.isSignedIn()) {
-      return this.currentUser_.w3.ig;
+      return this.currentUser_.getName;
+      //return this.currentUser_.w3.ig;
     }
     // TODO: replace with thrown error
     return null;


### PR DESCRIPTION
This fixes the issue, but now the user name isn't being automatically displayed on the page or populated in the SE name field. Can't figure out the right parameter to use to get the user name automatically from gapi. 